### PR TITLE
Update Warning commands requirements

### DIFF
--- a/mod/docs/index.md
+++ b/mod/docs/index.md
@@ -51,8 +51,8 @@ Moderation commands are available through Cliptok and Dyno. Some commands are re
 | Unmute member                | !unmute <​member>                                | All moderators        |
 | Warn member                  | !warn <​member> <​reason>                        | All moderators        |
 | Anonymously warn member      | !anonwarn <​channel> <​member> [reason]          | All moderators        |
-| Edit member's infraction     | !editwarn <​member> <​warning ID> <​reason>      | Permanent moderators  |                      
-| Remove member's infraction   | !delwarn <​member> <​warning ID>                 | Permanent moderators  |
+| Edit member's infraction     | !editwarn <​member> <​warning ID> <​reason>      | All moderators (Pernament moderators for warnings not created by themselves) |                      
+| Remove member's infraction   | !delwarn <​member> <​warning ID>                 | All moderators (Pernament moderators for warnings not created by themselves) |
 | Display member’s infractions | !infractions [member]                            | All members           |
 | Grant Tier 1 to member       | !grant [member]                                  | Permanent moderators  |
 | Clear messages               | !clear [member] <​number of messages>            | All moderators        |


### PR DESCRIPTION
Edit warnings and Remove warnings commands allows Trial Moderators, but only Permanent Moderators can Edit/Delete warnings they didn't create.