### PR TITLE
Remove remaining DiscordHub links

### DIFF
--- a/about/bots.md
+++ b/about/bots.md
@@ -23,7 +23,7 @@ You can find Corpinator [here](https://github.com/Cisien/corpinator).
 
 ### Dotsimus
 
-Dotsimus, developed by [Jaska](https://discordhub.com/profile/71270107371802624), is a moderation bot using the magic of machine learning to help detect toxicity and flag potentially offensive messages and users for the mods to review manually.
+Dotsimus, developed by Jaska, is a moderation bot using the magic of machine learning to help detect toxicity and flag potentially offensive messages and users for the mods to review manually.
 
 You can find Dotsimus' website [here](https://dotsimus.com/). Additionally, you can find the server containing more details as well as a place to play with it [here](https://discord.gg/VqKQf4M).
 

--- a/about/contributors.md
+++ b/about/contributors.md
@@ -4,12 +4,12 @@ sidebar: false
 
 ## Website contributors
 * Initial website content foundation by [Molly](https://github.com/mollymilllions)
-* General website maintenance, feature additions by [Jaska](https://discordhub.com/profile/71270107371802624), [Erisa](https://github.com/Erisa) and [Kirby](https://discordhub.com/profile/382218717997826048)
-* Information for members facing documentation by [Torch](https://discordhub.com/profile/159016432498114560)
+* General website maintenance, feature additions by Jaska, [Erisa](https://github.com/Erisa) and Kirby
+* Information for members facing documentation by Torch
 * Hero image of [Bit the Developer Advocate Mascot](https://github.com/ashleymcnamara/Developer-Advocate-Bit) by [Ashley McNamara](http://www.ashleymcnamara.com) licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 ## Community contributors
-* Seasonal, occassion/events based logos provided by [Torch](https://discordhub.com/profile/159016432498114560)
-* Informational technical support documentation provided by [Shoreditch](https://discordhub.com/profile/168883442145034241)
+* Seasonal, occassion/events based logos provided by Torch
+* Informational technical support documentation provided by Shoreditch
 * Some Wiki entries and cleanup fixes by [cleverActon0126](https://github.com/cleverActon0126)
 * Some Wiki entries by [Cutechri](https://github.com/CuteCry)

--- a/member/lounge.md
+++ b/member/lounge.md
@@ -4,7 +4,7 @@ sidebar: false
 
 <template>
 <h1>Lounge names history</h1>
-<em>List is curated by <a href="https://discordhub.com/profile/159016432498114560">Torch</a></em><hr>
+<em>List is curated by Torch</em><hr>
 <div id="loungeNames"><h2>Loading...</h2></div>
 </template>
 <style>


### PR DESCRIPTION
There is a commit that removed "all" DiscordHub links, though it only does for moderators.
I also saw a pull request where the idea to remove them from all moderators was discussed, but doesn't really say "all", which brought me a doubt.

I thought removing that website from every page would make more sense considering there are members (moderators like Kirby and Torch) that have the link on other pages but not on the moderation page (when they used to).

I know this is a minor change and I'm sorry if it's not right but it's something that doesn't seem intentional considering the commit message.