### PR TITLE
Made most wiki images take up the entire article's available width.

### DIFF
--- a/src/mod/index.md
+++ b/src/mod/index.md
@@ -5,5 +5,5 @@
 * [Statbot](https://statbot.net/dashboard/150662382874525696)
 * [Carbonitex](https://carbonitex.net/Discord/server?s=150662382874525696)
 
-## Documentations
+## Documentation
 * [Moderator Documentation](docs/)

--- a/src/wiki/backup.md
+++ b/src/wiki/backup.md
@@ -48,13 +48,19 @@ System Image Backup is another tool you can use to back up your system. A system
 
 #### To set up System Image Backup:
 
-1. Access the File History page of Control Panel with the steps above, then choose "System Image Backup" in the sidebar, or go to Control Panel > System and Security > Backup and Restore (Windows 7):  
-<img src="./img/backup/system-image-backup.png" width=400px>
-<img src="./img/backup/control-panel-backup-and-restore.png" width=800px>
-3. Click on "Create a system image":  
-<img src="./img/backup/create-a-system-image.png" width=500px>
-4. Follow the prompts to set up System Image Backup:  
-<img src="./img/backup/create-system-image-wizard.png" width=500px>
+1. Access the File History page of Control Panel with the steps above, then choose "System Image Backup" in the sidebar, or go to Control Panel > System and Security > Backup and Restore (Windows 7):
+    
+    ![](./img/backup/system-image-backup.png)
+    <br><br>
+    ![](./img/backup/control-panel-backup-and-restore.png)
+    
+2. Click on "Create a system image":  
+
+    ![](./img/backup/create-a-system-image.png)
+
+3. Follow the prompts to set up System Image Backup:  
+
+    ![](./img/backup/create-system-image-wizard.png)
 
 ## Backing Up to a Cloud Service
 
@@ -71,11 +77,14 @@ If you do not already have OneDrive installed, you can download it [here](https:
 #### Setting up OneDrive
 
 1. Click the OneDrive icon in your system tray (this is the area of your taskbar by the clock) to open its menu. If you do not see the OneDrive icon, you may need to click the 'Show hidden icons' button:  
-<img src="./img/backup/show-hidden-icons.png" width=150px>
+    ![](./img/backup/show-hidden-icons.png)
 2. Click the gear icon (Help & Settings), then Settings to open OneDrive's settings menu
-3. Click the "Backup" tab (may also be called "Sync and backup" in newer versions of Windows or OneDrive) and select "Manage backup", then select the folders you'd like to back up:  
-<img src="./img/backup/onedrive-manage-backup.png" width=450px>   
-<img src="./img/backup/onedrive-backup-select-page.png" width=450px>  
+3. Click the "Backup" tab (may also be called "Sync and backup" in newer versions of Windows or OneDrive) and select "Manage backup", then select the folders you'd like to back up:
+
+    ![](./img/backup/onedrive-manage-backup.png)
+    <br><br>
+    ![](./img/backup/onedrive-backup-select-page.png)
+
 4. Click the "Start backup" button to start backing up your selected folders. After this completes, OneDrive will continue to automatically back up files in your chosen folders as they are modified, or new files as they are added.
 
 By default, you can find your backed up files in your user folder (`C:\Users\[your user name here]\OneDrive`) or at [onedrive.live.com](https://onedrive.live.com).
@@ -89,10 +98,15 @@ Google Drive is another cloud service that can back up your files. Like OneDrive
 If you do not already have Google Drive installed, you can download it [here](https://www.google.com/drive/download). Once downloaded, install it and sign in with your Google account.
 
 1. Click the Google Drive icon in your system tray (this is the area of your taskbar by the clock) to open its menu. If you do not see the Google Drive icon, you may need to click the 'Show hidden icons' button:  
-![](./img/backup/show-hidden-icons.png)
-2. Click the gear icon, then Preferences to open Google Drive's settings menu:  
-<img src="./img/backup/google-drive-prefs.png" width=500px>
+
+    ![](./img/backup/show-hidden-icons.png)
+
+2. Click the gear icon, then Preferences to open Google Drive's settings menu:
+
+    ![](./img/backup/google-drive-prefs.png)
+
 3. In the "My Computer" tab, select "Add folder" to choose a folder to sync with Google Drive:  
-<img src="./img/backup/google-drive-folder-settings.png" width=500px>  
+
+    ![](./img/backup/google-drive-folder-settings.png)
 
 By default, you can find your backed up files in the Google Drive Streaming folder (`C:\Users\[your user name here]\Google Drive Streaming`) or at [drive.google.com](https://drive.google.com).

--- a/src/wiki/common-misconceptions.md
+++ b/src/wiki/common-misconceptions.md
@@ -42,7 +42,7 @@ This one is a result of the media taking things out of proportion, sensationaliz
 
 As for the "ads" in the File Explorer, they were not ads. They were either reminders for important tasks such as backing up:
 
-<img src="./img/common-misconceptions/reminder.png" width=1000px>
+![](./img/common-misconceptions/reminder.png)
 
 Or they were suggestions for other Microsoft products, such as Microsoft Editor, that come at no additional cost (although it has more features if you have a 365 subscription). Again, some people might find those apps useful. An actual ad would be other companies paying Microsoft to put advertisements to _their_ products in the OS, which deserves tons of criticism - but them recommending their own products in their own OS doesn't. If you are a power user who does not make any use of the suggested apps, the option to simply dismiss the small banner is there, and you can even turn off suggestions altogether should these "ads" ever make it into Windows.
 

--- a/src/wiki/fixing-microsoft-store.md
+++ b/src/wiki/fixing-microsoft-store.md
@@ -14,11 +14,11 @@ There are two ways to clear the Microsoft Store cache.
 
 2. Click *Apps*.
 
-    <img src="./img/fixing-microsoft-store/apps.png" width=300px>
+    ![](./img/fixing-microsoft-store/apps.png)
 
 3. Find *Microsoft Store*, click it, and click *Advanced options*.
 
-    <img src="./img/fixing-microsoft-store/microsoftstore.png" width=500px>
+    ![](./img/fixing-microsoft-store/microsoftstore.png)
 
 ::: tip Note
 If you don't see *Microsoft Store* here, you will have to reinstall it completely. Skip to [Method 2](#method-2-reinstalling-the-microsoft-store).
@@ -26,7 +26,7 @@ If you don't see *Microsoft Store* here, you will have to reinstall it completel
 
 4. Scroll down and click the *Reset* button. Then wait for a check mark to appear. Once you see the check mark, you're done; if the Microsoft Store still doesn't work, try the next option below.
 
-    <img src="./img/fixing-microsoft-store/resetmicrosoftstore.png" width=500px>
+    ![](./img/fixing-microsoft-store/resetmicrosoftstore.png)
 
 ### Clearing the Microsoft Store cache with `wsreset`
 
@@ -50,7 +50,7 @@ The `wsreset` function is outdated and may not function correctly in the latest 
 
     Once PowerShell is open, it should look like the image below:
 
-    <img src="./img/fixing-microsoft-store/powershell.png" width=600px>
+    ![](./img/fixing-microsoft-store/powershell.png)
 
 2. Type or paste `Get-AppxPackage *windowsstore* | Remove-AppxPackage` and press <kbd>Enter</kbd>.
 
@@ -58,14 +58,14 @@ The `wsreset` function is outdated and may not function correctly in the latest 
     This command will completely remove the Microsoft Store from your PC. The command in the next step will reinstall it.
     :::
 
-    <img src="./img/fixing-microsoft-store/removingmicrosoftstore.png" width=600px>
+    ![](./img/fixing-microsoft-store/removingmicrosoftstore.png)
 
 3. After the last command finishes, type or paste `Get-AppXPackage *WindowsStore* -AllUsers | Foreach {Add-AppxPackage -DisableDevelopmentMode -Register "$($_.InstallLocation)\AppXManifest.xml"}` and press <kbd>Enter</kbd>.
 
-    <img src="./img/fixing-microsoft-store/installingmicrosoftstore.png" width=600px>
+    ![](./img/fixing-microsoft-store/installingmicrosoftstore.png)
 
 4. After completing these steps, PowerShell should look like the image below. If it looks different or displays any errors, make sure you typed the commands correctly.
 
-    <img src="./img/fixing-microsoft-store/afterinstallingmicrosoftstore.png" width=600px>
+    ![](./img/fixing-microsoft-store/afterinstallingmicrosoftstore.png)
 
 If PowerShell looks like the image above, restart your PC to ensure any changes are applied, then try opening the Microsoft Store again. If you are still having issues, try [repairing Windows](https://msft.chat/wiki/using-the-media-creation-tool.html#method-1-repairing-an-existing-installation).

--- a/src/wiki/hacked-accounts.md
+++ b/src/wiki/hacked-accounts.md
@@ -14,7 +14,7 @@ Keep in mind that this is not a 100% guarantee to get your account back, having 
 1. At the option 'Choose how you normally sign in, then enter your details.', select 'With an email address'.
 2. Fill in the email address you normally sign in with and press 'OK'.
 
-<img src="./img/hacked-accounts/sign-in-option.png" alt="Sign in option with hidden email address." width="500px">
+    ![Sign in option with hidden email address.](./img/hacked-accounts/sign-in-option.png)
 
 3. After it has done some tests, press 'continue'. 
 
@@ -26,30 +26,30 @@ If it gives the error "Username not found", proceed to [this section](#username-
 4. At the option 'Please select an option', select 'Account hacked'.
 5. At the option 'Please select the reason why you think your account has been hacked.', select 'Unusual account activity'.
 
-<img src="./img/hacked-accounts/unusual-activity.png" alt="Option with account hacked and unusual activity." width="500px">
+    ![Option with account hacked and unusual activity.](./img/hacked-accounts/unusual-activity.png)
 
 6. At the option 'Are you able to sign in to your account?', select 'No'.
 7. At the option 'Were you able to recover your account?', select 'I don't recognize the phone/email'.
 
-::: warning
-Do not click on the link 'Recover your account'. This will not give you live support!
-:::
+    ::: warning
+    Do not click on the link 'Recover your account'. This will not give you live support!
+    :::
 
-<img src="./img/hacked-accounts/cannot-sign-in.png" alt="Options showing the unrecoverable account options." width="500px">
+    ![Options showing the unrecoverable account options.](./img/hacked-accounts/cannot-sign-in.png)
 
 8. Click 'Continue' until it is at the 'Microsoft account recovery' step.
 9. At the option 'Were you able to submit the recovery form?', select 'No'.
 
-::: warning
-Do not click on the link 'Recover your account'. This will not give you live support!
-:::
+    ::: warning
+    Do not click on the link 'Recover your account'. This will not give you live support!
+    :::
 
-<img src="./img/hacked-accounts/continue-part1.png" alt="The buttons with continue." width="500px">
-<img src="./img/hacked-accounts/continue-part2.png" alt="Buttons with continue and the recovery form question." width="500px">
+    ![The buttons with continue.](./img/hacked-accounts/continue-part1.png)
+    ![Buttons with continue and the recovery form question.](./img/hacked-accounts/continue-part2.png)
 
 10. Press the chat button to start a live chat with Microsoft support.
 
-<img src="./img/hacked-accounts/starting-chat.png" alt="The live chat button" width="500px">
+    ![The live chat button.](./img/hacked-accounts/starting-chat.png)
 
 11. Fill in the form for the live chat and click 'Submit'
 
@@ -59,18 +59,18 @@ If you get the error 'Username not found' proceed with this guide:
 
 1. At the option 'Are you sure your username is correct?', click 'Yes'.
 
-<img src="./img/hacked-accounts/username-not-found.png" alt="Username not found" width="500px">
+    ![Username not found.](./img/hacked-accounts/username-not-found.png)
 
 2. At the option 'Were you able to recover your account?', click 'No. I still see "We don't recognise the account".
 
-::: warning
-Do not click on the link 'Recover your account'. This will not give you live support!
-:::
+    ::: warning
+    Do not click on the link 'Recover your account'. This will not give you live support!
+    :::
 
-<img src="./img/hacked-accounts/still-no-account.png" alt="Username not found" width="500px">
+    ![Steps to take if username stops working.](./img/hacked-accounts/still-no-account.png)
 
 3. Press the chat button to start a live chat with Microsoft support.
 
-<img src="./img/hacked-accounts/starting-chat.png" alt="The live chat button" width="500px">
+    ![The live chat button.](./img/hacked-accounts/starting-chat.png)
 
 4. Fill in the form for the live chat and click 'Submit'

--- a/src/wiki/installing-and-updating-drivers.md
+++ b/src/wiki/installing-and-updating-drivers.md
@@ -29,19 +29,19 @@ On Windows 11:
 
 1. Click "Advanced options".
 
-   <img src="./img/installing-and-updating-drivers/optional-updates/windows-update-advanced-options.png" alt="Windows 11's Windows Update settings, with the Advanced options button highlighted." width="500px">
+   ![Windows 11's Windows Update settings, with the Advanced options button highlighted.](./img/installing-and-updating-drivers/optional-updates/windows-update-advanced-options.png)
 
 2. Click "Optional updates".
 
-   <img src="./img/installing-and-updating-drivers/optional-updates/windows-update-advanced-options-optional-updates.png" alt="The Advanced options menu, with the Optional updates button highlighted." width="500px">
+   ![The Advanced options menu, with the Optional updates button highlighted.](./img/installing-and-updating-drivers/optional-updates/windows-update-advanced-options-optional-updates.png)
 
 3. Click "Driver updates" to show the list of available driver updates, if there are any.
 
-   <img src="./img/installing-and-updating-drivers/optional-updates/windows-update-optional-updates-driver-updates.png" alt="The Optional updates menu, with the Driver updates menu highlighted." width="500px">
+   ![The Optional updates menu, with the Driver updates menu highlighted.](./img/installing-and-updating-drivers/optional-updates/windows-update-optional-updates-driver-updates.png)
 
 4. Select any optional updates you wish to install, then click "Download & install".
 
-   <img src="./img/installing-and-updating-drivers/optional-updates/windows-update-driver-update-example.png" alt="An available optional driver update, with the Download & install button selected." width="500px">
+   ![An available optional driver update, with the Download & install button selected.](./img/installing-and-updating-drivers/optional-updates/windows-update-driver-update-example.png)
 
 On Windows 10, a "View optional updates" link will appear under "Check for updates" if optional updates are available. Click on it to see the list of available driver updates.
 
@@ -108,23 +108,23 @@ Verifying driver signatures ensures you are installing secure, untampered and co
 
 1. Press <kbd>Win</kbd> + <kbd>X</kbd> and then clicking the "Device Manager" option. You can also search for it in the Start Menu.
 
-   <img src="./img/installing-and-updating-drivers/troubleshooting/device-manager-power-user-menu.png" alt="The Win+X 'power user' menu, with Device Manager highlighted." height="400px">
+   ![The Win+X 'power user' menu, with Device Manager highlighted.](./img/installing-and-updating-drivers/troubleshooting/device-manager-power-user-menu.png)
 
 2. In Device Manager, find the device that is causing problems (you might have to expand a category), right-click on it, and click "Properties".
 
-   <img src="./img/installing-and-updating-drivers/troubleshooting/device-manager-properties-button.png" alt="The context menu for a display adapter in Device Manager, with Properties highlighted." width="500px">
+   ![The context menu for a display adapter in Device Manager, with Properties highlighted.](./img/installing-and-updating-drivers/troubleshooting/device-manager-properties-button.png)
 
 3. Go to the "Driver" tab at the top of the window, and then click "Roll Back Driver".
 
-   <img src="./img/installing-and-updating-drivers/troubleshooting/device-manager-properties-roll-back-driver.png" alt="The properties window for a device in Device Manager, with the Driver tab and Roll Back Driver button highlighted." width="300px">
+   ![The properties window for a device in Device Manager, with the Driver tab and Roll Back Driver button highlighted.](./img/installing-and-updating-drivers/troubleshooting/device-manager-properties-roll-back-driver.png)
 
 4. Windows will ask you why you're rolling back to a previous driver. Select a reason, and click "Yes". If you want to, you can leave a detailed response in the "Tell Us More" field, at the bottom of the window.
 
-   <img src="./img/installing-and-updating-drivers/troubleshooting/driver-rollback-confirmation.png" alt="The confirmation dialogue presented after selecting Roll Back Driver." width="300px">
+   ![The confirmation dialogue presented after selecting Roll Back Driver.](./img/installing-and-updating-drivers/troubleshooting/driver-rollback-confirmation.png)
 
 5. Windows will then restore your driver to the previous version, which could take up to 5-10 minutes.
 
-   <img src="./img/installing-and-updating-drivers/troubleshooting/hardware-change-restart-prompt.png" alt="The prompt to restart your computer, shown after rolling back a driver." width="500px">
+   ![The prompt to restart your computer, shown after rolling back a driver.](./img/installing-and-updating-drivers/troubleshooting/hardware-change-restart-prompt.png)
 
 ### Safe Mode
 Safe mode is a diagnostic tool, which loads Windows with only the essential drivers. This allows you to access Windows even if the problematic driver is causing issues during normal boot.
@@ -138,15 +138,15 @@ Safe mode is a diagnostic tool, which loads Windows with only the essential driv
 
    2. Click on "Troubleshoot"
 
-      <img src="./img/installing-and-updating-drivers/winre/choose_an_option_screen.png" alt="A screenshot showing the Windows Recovery Environment screen with an arrow pointing at the Troubleshoot button." width="500px">
+      ![A screenshot showing the Windows Recovery Environment screen with an arrow pointing at the Troubleshoot button.](./img/installing-and-updating-drivers/winre/choose_an_option_screen.png)
 
    3. Then, select "Advanced options"
 
-      <img src="./img/installing-and-updating-drivers/winre/troubleshoot_screen.png" alt="A screenshot of the Troubleshooting menu in the Windows Recovery Environment with the Advanced Options button highlighted." width="500px">
+      ![A screenshot of the Troubleshooting menu in the Windows Recovery Environment with the Advanced Options button highlighted.](./img/installing-and-updating-drivers/winre/troubleshoot_screen.png)
 
    4. Finally, click "Startup Settings" and then "Restart".
 
-      <img src="./img/installing-and-updating-drivers/winre/advanced_options_screen.png" alt="A screenshot of the Advanced Options menu in the Windows Recovery Environment, with the Startup Settings button highlighted." width="500px">
+      ![A screenshot of the Advanced Options menu in the Windows Recovery Environment, with the Startup Settings button highlighted.](./img/installing-and-updating-drivers/winre/advanced_options_screen.png)
 
    After your computer restarts, press <kbd>4</kbd> to boot into Safe Mode, or <kbd>5</kbd> to boot into Safe Mode with internet access.
 
@@ -163,23 +163,23 @@ Safe mode is a diagnostic tool, which loads Windows with only the essential driv
 
    2. Expand the category for the device with the recently installed driver.
 
-      <img src="./img/installing-and-updating-drivers/troubleshooting/device-manager-properties-button.png" alt="The context menu for a display adapter in Device Manager, with Properties highlighted." width="500px">
+      ![The context menu for a display adapter in Device Manager, with Properties highlighted.](./img/installing-and-updating-drivers/troubleshooting/device-manager-properties-button.png)
 
    3. In Device Manager, find the device that is causing problems (you might have to expand a category), right-click on it, and click "Properties".
 
-      <img src="./img/installing-and-updating-drivers/troubleshooting/device-manager-properties-roll-back-driver.png" alt="The properties window for a device in Device Manager, with the Driver tab and Roll Back Driver button highlighted." width="300px">
+      ![The properties window for a device in Device Manager, with the Driver tab and Roll Back Driver button highlighted.](./img/installing-and-updating-drivers/troubleshooting/device-manager-properties-roll-back-driver.png)
 
    4. Go to the "Driver" tab at the top of the window, and then click "Roll Back Driver".
 
-      <img src="./img/installing-and-updating-drivers/troubleshooting/driver-rollback-confirmation.png" alt="The confirmation dialogue presented after selecting Roll Back Driver." width="300px">
+      ![The confirmation dialogue presented after selecting Roll Back Driver.](./img/installing-and-updating-drivers/troubleshooting/driver-rollback-confirmation.png)
 
    5. Windows will ask you why you're rolling back to a previous driver. Select a reason, and click "Yes". If you want to, you can leave a detailed response in the "Tell Us More" field, at the bottom of the window.
 
-      <img src="./img/installing-and-updating-drivers/troubleshooting/driver-rollback-confirmation.png" alt="The confirmation dialogue presented after selecting Roll Back Driver." width="300px">
+      ![The confirmation dialogue presented after selecting Roll Back Driver.](./img/installing-and-updating-drivers/troubleshooting/driver-rollback-confirmation.png)
 
    6. Windows will then restore your driver to the previous version, which could take up to 5-10 minutes.
 
-      <img src="./img/installing-and-updating-drivers/troubleshooting/hardware-change-restart-prompt.png" alt="The prompt to restart your computer, shown after rolling back a driver." width="500px">
+      ![The prompt to restart your computer, shown after rolling back a driver.](./img/installing-and-updating-drivers/troubleshooting/hardware-change-restart-prompt.png)
 
 
 Or if you can't access the normal safe mode, you may try and access Safe Mode with Command Prompt and execute the following commands in Command Prompt (replace `not_working_driver` with the driver that isn't working):
@@ -198,29 +198,29 @@ The operation completed successfully.
 
 1. At startup options, click Troubleshoot.
 
-   <img src="./img/installing-and-updating-drivers/winre/choose_an_option_screen.png" alt="An image of advanced startup" width="500px">
+   ![Screen showing advanced startup options, titled "Choose an option".](./img/installing-and-updating-drivers/winre/choose_an_option_screen.png)
 
 2. Then, click on "Advanced Options"
 
-   <img src="./img/installing-and-updating-drivers/winre/troubleshoot_screen.png" alt="An image to entrace to advanced options" width="500px">
+   ![The Windows Recovery Environment's troubleshoot screen.](./img/installing-and-updating-drivers/winre/troubleshoot_screen.png)
 
 3. Finally, click on "System Restore" and follow the instructions
 
-   <img src="./img/installing-and-updating-drivers/winre/advanced_options_screen.png" alt="An image to enter to system restore menu" width="500px">
+   ![Screen in the Windows Recovery Environment, titled "Advanced options", with the option "System Restore" highlighted.](./img/installing-and-updating-drivers/winre/advanced_options_screen.png)
 
 ### Startup Repair
     
    1. Select "Troubleshoot"
 
-      <img src="./img/installing-and-updating-drivers/winre/choose_an_option_screen.png" alt="An image to enter to system restore menu" width="500px">
+      ![Screen showing advanced startup options, titled "Choose an option".](./img/installing-and-updating-drivers/winre/choose_an_option_screen.png)
     
    2. Select "Advanced options"
     
-      <img src="./img/installing-and-updating-drivers/winre/troubleshoot_screen.png" alt="An image to entrace to advanced options" width="500px">
+      ![The Windows Recovery Environment's troubleshoot screen.](./img/installing-and-updating-drivers/winre/troubleshoot_screen.png)
     
    3. Select "Startup Repair"
     
-      <img src="./img/installing-and-updating-drivers/winre/advanced_options_screen.png" alt="An image to click startup repair" width="500px">
+      ![Screen in the Windows Recovery Environment, titled "Advanced options".](./img/installing-and-updating-drivers/winre/advanced_options_screen.png)
 
 ### Reinstall Windows
 

--- a/src/wiki/troubleshooting.md
+++ b/src/wiki/troubleshooting.md
@@ -6,7 +6,7 @@ This utility scans the system for issues with the Windows Component Store and Wi
 
 To scan and repair those files, run `DISM /Online /Cleanup-Image /RestoreHealth` from an elevated command prompt.
 
-For more information about running DISM check [this page](https://support.microsoft.com/en-us/help/947821/fix-windows-update-errors-by-using-the-dism-or-system-update-readiness)
+For more information about running DISM check [this page](https://support.microsoft.com/en-us/help/947821/fix-windows-update-errors-by-using-the-dism-or-system-update-readiness).
 
 ## SFC
 

--- a/src/wiki/useful-windows-tips.md
+++ b/src/wiki/useful-windows-tips.md
@@ -10,7 +10,7 @@ The context menu is the pop-up menu that appears when you right-click on a file 
 
 In Windows 11, the new context menu was introduced which has fewer options and some of them are replaced with icons. At the bottom, there is an option to "Show more options" which will show the legacy menu.
 
-<img src="./img/useful-windows-tips/new-context-menu.png" alt="Screenshot of the new context menu, introduced in Windows 11." width="150">
+<img src="./img/useful-windows-tips/new-context-menu.png" alt="Screenshot of the new context menu, introduced in Windows 11." width="200px">
 
 However, if you prefer the legacy menu, and you don't want to click "Show more options" every time, you can modify a registry key to disable the new context menu. To do that, open Powershell and run the following command
 
@@ -18,17 +18,15 @@ However, if you prefer the legacy menu, and you don't want to click "Show more o
 reg.exe add "HKCU\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32" /f /ve
 ```
 
-<img src="./img/useful-windows-tips/powershell-legacy-context-menu.png" alt="Screenshot of a Powershell window, running the command above." width="600px">
-
+![Screenshot of a Powershell window, running the command above.](./img/useful-windows-tips/powershell-legacy-context-menu.png)
 
 Then, open the Task Manager, and search for _Windows Explorer_, then right-click on the process and click Restart. If you right-click a file or folder, you should now see the legacy context menu.
 
-<img src="./img/useful-windows-tips/legacy-context-menu.png" alt="Screenshot of the legacy context menu." width="200">
+<img src="./img/useful-windows-tips/legacy-context-menu.png" alt="Screenshot of the legacy context menu." width="200px">
 
 ::: tip Note
 When holding down <kbd>Shift</kbd> when right-clicking, the legacy context menu will always appear (and with the extra options as described in the previous tip), even without modifying this registry key.
 :::
-
 
 ## Windows Master Control Panel shortcut
 
@@ -39,7 +37,6 @@ To create the shortcut, create a folder and name it `allSettings.{ED7BA470-8E54-
 The text in front of the dot has no effect. You may change it to whatever you want, but the shortcut will appear to have no name.
 
 You can now open the folder to find all control panel settings.
-
 
 ## Make Windows search faster
 
@@ -89,19 +86,19 @@ Although indexing is enabled by default, it only indexes important folders, such
 
 First, search for "Indexing Options" in the Start menu.
 
-<img src="./img/useful-windows-tips/search-indexing-options.png" alt="Screenshot of the user searching for the Indexing Options in the Start menu search." height="200">
+<img src="./img/useful-windows-tips/search-indexing-options.png" alt="Screenshot of the user searching for the Indexing Options in the Start menu search." height="200px">
 
 Then, in the window that appears, click "Modify".
 
-<img src="./img/useful-windows-tips/indexing-modify.png" alt="Screenshot of the Indexing Options window with the modify button highlighted." height="400">
+<img src="./img/useful-windows-tips/indexing-modify.png" alt="Screenshot of the Indexing Options window with the modify button highlighted." height="400px">
 
 Then, click "Show All Locations".
 
-<img src="./img/useful-windows-tips/indexing-show-all-locations.png" alt="Screenshot of the Indexed Locations window with the Show All Locations button highlighted." height="400">
+<img src="./img/useful-windows-tips/indexing-show-all-locations.png" alt="Screenshot of the Indexed Locations window with the Show All Locations button highlighted." height="400px">
 
 Now, check all the locations that you want Windows to index. Finally, click Ok to confirm.
 
-<img src="./img/useful-windows-tips/indexing-check-all-and-ok.png" alt="Screenshot of the Indexed Locations window with the location checkboxes and the Ok button highlighted." height="400">
+<img src="./img/useful-windows-tips/indexing-check-all-and-ok.png" alt="Screenshot of the Indexed Locations window with the location checkboxes and the Ok button highlighted." height="400px">
 
 Your files will now be indexed.
 
@@ -121,7 +118,7 @@ In the details view in File Explorer, you can show more columns in addition to t
 
 To do that, right-click on the columns in the Details view, and then choose More. You can then enable the columns you want to see by checking them.
 
-<img src="./img/useful-windows-tips/enable-more-columns-fileExplorer.png" alt="Screenshot of the window for adding more columns to the File Explorer details view." height=350px>
+![Screenshot of the window for adding more columns to the File Explorer details view.](./img/useful-windows-tips/enable-more-columns-fileExplorer.png)
 
 ## Voice typing
 
@@ -130,7 +127,7 @@ without actually typing, but by speaking into your microphone instead.
 
 To use Voice Typing, press <kbd>Win</kbd> + <kbd>H</kbd>, and a small window will appear.
 
-<img src="./img/useful-windows-tips/voice-typing-window.png" alt="Screenshot of the voice typing window." height=100px>
+![Screenshot of the voice typing window.](./img/useful-windows-tips/voice-typing-window.png)
 
 If it does not turn on automatically, simply click on the microphone button. Now, you can speak into your microphone to enter text, instead of typing!
 
@@ -139,9 +136,10 @@ You can keep the calculator window always on top, so that it stays pinned on you
 
 To do that, press the icon next to "Standard" that looks like a box with an arrow. Calculator will now stay on top of all windows.
 
-<img src="./img/useful-windows-tips/calculator-always-on-top.png" alt="Screenshot of the calculator app with the always on top button highlighted." height=350px>
+![Screenshot of the calculator app with the always on top button highlighted.](./img/useful-windows-tips/calculator-always-on-top.png)
 
 ## Additional clocks
+
 By default, the clock on the right side of the taskbar shows the local time. But you can add two additional clocks that show the time in a chosen timezone.
 
 To do that, right-click on the clock on the taskbar, and click "Adjust date and time".
@@ -149,13 +147,13 @@ Then, scroll down to the bottom of the page, and click "Additional Clocks".
 
 In the window that appears, you can check one or both clocks, select their timezone, and add a name.
 
-<img src="./img/useful-windows-tips/additional-clocks.png" alt="Screenshot of the additional clocks window." height=350px>
+![Screenshot of the additional clocks window.](./img/useful-windows-tips/additional-clocks.png)
 
-Click Ok to save the settings you changed.
+Click OK to save the settings you changed.
 
 If you hover over the taskbar clock, you should now see your additional clocks.
 
-<img src="./img/useful-windows-tips/hovering-over-taskbar-clock.png" alt="Screenshot of the popup with the additional clocks when hovering over the taskbar clock." height=150px>
+![Screenshot of the popup with the additional clocks when hovering over the taskbar clock.](./img/useful-windows-tips/hovering-over-taskbar-clock.png)
 
 ## Clipboard history
 
@@ -164,11 +162,11 @@ You can view your clipboard history, which is a list of the last 25 objects that
 To do that, press <kbd>Win</kbd> + <kbd>V</kbd>, and a small window will appear. If it's the first time you are using the Clipboard History feature, you will see a button that says "Turn On"
 as it's disabled by default.
 
-<img src="./img/useful-windows-tips/turn-on-clipboard-history.png" alt="Screenshot of the clipboard history window with the Turn On button visible." height=300px>
+![Screenshot of the clipboard history window with the Turn On button visible.](./img/useful-windows-tips/turn-on-clipboard-history.png)
 
 After clicking on it, everything you copy will be logged there. You can then "go back in history" and paste something you copied earlier.
 
-<img src="./img/useful-windows-tips/clipboard-history-list.png" alt="Screenshot of the clipboard history window showing text that was copied earlier." height=300px>
+![Screenshot of the clipboard history window showing text that was copied earlier.](./img/useful-windows-tips/clipboard-history-list.png)
 
 You can click "Clear all" to empty the list. You can also click the pin icon next to an entry to keep it pinned forever<sup>1</sup>.
 
@@ -185,7 +183,7 @@ However, in Windows 11, there is also a new feature that allows you to snap wind
 To use it, hover over the maximize button of the window you want to snap, and the menu will appear. You can then choose where you want to snap
 the window, or even select one of the recommended window groups, which will snap all windows.
 
-<img src="./img/useful-windows-tips/window-snapping-menu.png" alt="Screenshot of windows snapping menu on the maximize button." height=300px>
+![Screenshot of windows snapping menu on the maximize button.](./img/useful-windows-tips/window-snapping-menu.png)
 
 ## Always show on-screen keyboard icon
 
@@ -195,17 +193,18 @@ for example, in case you don't have a physical keyboard attached to the computer
 To pin the icon, right click on the taskbar and choose "Taskbar settings".
 Then, under the "System tray icons" category, you will find the option "Touch keyboard".
 
-<img src="./img/useful-windows-tips/on-screen-keyboard-1.png" alt="Screenshot of the on-screen keyboard setting." width="675">
+![Screenshot of the on-screen keyboard setting.](./img/useful-windows-tips/on-screen-keyboard-1.png)
 
 You can select "When no keyboard attached", which will only show the icon when a physical keyboard is not plugged in, or "Always" which will always keep the icon pinned
 on the taskbar.
 
-<img src="./img/useful-windows-tips/on-screen-keyboard-2.png" alt="Screenshot of the on-screen keyboard dropdown options." width="225">
+![Screenshot of the on-screen keyboard dropdown options.](./img/useful-windows-tips/on-screen-keyboard-2.png)
 
 You will then find the keyboard icon on the tray area of the taskbar.
 
-<img src="./img/useful-windows-tips/on-screen-keyboard-3.png" alt="Screenshot of the on-screen keyboard icon on the taskbar tray." width="175"><br><br>
-<img src="./img/useful-windows-tips/on-screen-keyboard.png" alt="Screenshot of the on-screen keyboard." width="550">
+![Screenshot of the on-screen keyboard icon on the taskbar tray.](./img/useful-windows-tips/on-screen-keyboard-3.png)
+<br><br>
+![Screenshot of the on-screen keyboard.](./img/useful-windows-tips/on-screen-keyboard.png)
 
 ## Speed up File Explorer for big folders
 

--- a/src/wiki/windows-insiders.md
+++ b/src/wiki/windows-insiders.md
@@ -12,27 +12,27 @@ You must be logged onto a Microsoft Account to be able to join the Windows Insid
 
 1. Open the Settings app. You can do this by searching for it in the Start menu, clicking <kbd>Win</kbd> + <kbd>I</kbd>, or clicking the Settings button found above the Power button in Start. After that, open the **Winodws Update** Section.
 
-<img src="./img/windows-insider/11/settings-home.png" width="500px">
+![](./img/windows-insider/11/settings-home.png)
 
 2. Click on **Windows Insider Program** navigate to the sign up page.
 
-<img src="./img/windows-insider/11/settings-select.png" width="500px">
+![](./img/windows-insider/11/settings-select.png)
 
 3. Click on the **Get Started** button to join the Windows Insider Program.
 
-<img src="./img/windows-insider/11/get-started.png" width="500px">
+![](./img/windows-insider/11/get-started.png)
 
 4. Click on **Link an account** to link a Microsoft Account.
 
-<img src="./img/windows-insider/11/link-an-account.png" width="500px">
+![](./img/windows-insider/11/link-an-account.png)
 
 5. Select an account or login with one by clicking **Microsoft Account**, then click **Continue**. 
 
-<img src="./img/windows-insider/11/login.png">
+<img src="./img/windows-insider/11/login.png" width="400px">
 
 6. Read the [Microsoft Insider Program Agreement](https://insider.windows.com/program-agreement) and the [Microsoft Insider Privacy Agreement](https://privacy.microsoft.com/privacystatement). Click **Continue** when you finish reading and agree to the agreement.
 
-<img src="./img/windows-insider/11/agreements.png" width="500px">
+![](./img/windows-insider/11/agreements.png)
 
 ::: tip
 If this prompt appears more than one time, click **Continue** until it moves on to the next step.
@@ -40,14 +40,14 @@ If this prompt appears more than one time, click **Continue** until it moves on 
 
 7. Now select a channel to receive insider builds, then click **Confirm**. Here are some details on the details of the 3 channels:  
 
-| Channels                   | Description                                                                                                                                                                                                                                                               |
+| Channel                    | Description                                                                                                                                                                                                                                                               |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Canary Channel             | Ideal for highly technical users. Preview the latest platform changes early in the development cycle. These builds can be unstable and are released with limited to no documentation.                                                  |  
 | Dev Channel                | Ideal for enthusiasts. Access the latest Windows 11 preview builds as we incubate new ideas and develop long lead features. There will be some rough edges and low stability.                                                          |
 | Beta Channel (Recommended) | Ideal for early adopters. These Windows 11 builds will be more reliable than builds from our Dev Channel. woth updates validated by Microsoft. Your feedback has the greatest impact here.                                             |
 | Release Preview Channel    | Ideal if you want to preview and certain key features, plus get optional access to the next version of Windows before it's generally available to the world. This channel is also recommended for commercial users.                    |
 
-<img src="./img/windows-insider/11/channels.png" width="500px">
+![](./img/windows-insider/11/channels.png)
 
 ::: tip Note
 If you don't see all 4 channels, you might be limited by your hardware.
@@ -55,41 +55,41 @@ If you don't see all 4 channels, you might be limited by your hardware.
  
 8. Review the [Microsoft Insider Privacy Statement](https://privacy.microsoft.com/privacystatement) and the [Microsoft Insider Program Agreement](https://insider.windows.com/program-agreement), then click **Continue**.
 
-<img src="./img/windows-insider/11/agreement-2.png" width="500px">
+![](./img/windows-insider/11/agreement-2.png)
 
 9. Choose to *Restart Now* or *Restart Later*, then you will start receiving insider builds in *Settings> Updates & Security> Windows Update*. Have fun testing Windows Builds!
 
-<img src="./img/windows-insider/11/restart.png" width="500px">
+![](./img/windows-insider/11/restart.png)
 
 ### Joining the Windows Insider Program on Windows 10
 
 1. Open the Settings app. You can do this by searching for it in the Start menu, clicking <kbd>Win</kbd> + <kbd>I</kbd>, or clicking the Settings button found above the Power button in Start. After that, open the **Update & Security** Section.
 
-<img src="./img/windows-insider/10/settings-home.png" width="500px">
+![](./img/windows-insider/10/settings-home.png)
 
 2. Click on **Windows Insider Program** on the sidebar to navigate to the sign up page.
 
-<img src="./img/windows-insider/10/settings-select-side.png" width="500px">
+![](./img/windows-insider/10/settings-select-side.png)
 
 3. Click on the **Get Started** button to join the Windows Insider Program.
 
-<img src="./img/windows-insider/10/get-started.png" width="500px">
+![](./img/windows-insider/10/get-started.png)
 
 4. Click on **Register** to join the Windows Insider Program.
 
-<img src="./img/windows-insider/10/register.png" width="500px">
+![](./img/windows-insider/10/register.png)
 
 5. You will be prompted with a pop-up as shown below, click on **Sign Up**.
 
-<img src="./img/windows-insider/10/signup.png" width="500px">
+![](./img/windows-insider/10/signup.png)
 
 6. Read the [Windows Insider Program Agreement](https://insider.windows.com/program-agreement) and the [Microsoft Insider Privacy Agreement](https://privacy.microsoft.com/privacystatement), then check **I've read and accept the terms of this agreement** if you agree. Then click **Submit**.
 
-<img src="./img/windows-insider/10/agree-and-submit.png" width="500px">
+![](./img/windows-insider/10/agree-and-submit.png)
 
 Shortly after that you should see a pop-up saying that you have successfully singed up for the Windows Insider Program. You now have to choose an account to signup as a Windows Insider.
 
-<img src="./img/windows-insider/10/link-an-account.png" width="500px">
+![](./img/windows-insider/10/link-an-account.png)
 
 7. Link an account to join the Windows Insider Program, then click **Continue**.
 
@@ -97,17 +97,17 @@ Shortly after that you should see a pop-up saying that you have successfully sin
 You can choose any account to signup, but your personal Microsoft Account is recommmended.
 :::
 
-<img src="./img/windows-insider/10/account-link.png" width="350px">
+<img src="./img/windows-insider/10/account-link.png" width="400px">
 
 8. Now select a channel to receive insider builds, then click **Confirm**. Here are some details on the details of the 3 channels:
 
-| Channels                   | Description                                                                                                                                                                                                                                                               |
+| Channel                    | Description                                                                                                                                                                                                                                                               |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dev Channel                | Ideal for highly technical users. Be the first to access the latest Windows 11 builds earliest in the development cycle with the newest code. There will be some rought edges and low stability.                                       |
 | Beta Channel (Recommended) | Ideal for early adopters. These Windows 11 builds will be more reliable than builds from our Dev Channel. woth updates validated by Microsoft. Your feedback has the greatest impact here.                                             |
 | Release Preview Channel    | Ideal if you want to preview and certain key features, plus get optional access to the next version of Windows before it's generally available to the world. This channel is also recommended for commercial users.                    |
 
-<img src="./img/windows-insider/10/channels.png" width="500px">
+![](./img/windows-insider/10/channels.png)
 
 ::: tip Note
 If you don't see all 3 channels, you may be limited to certain channels by your hardware.
@@ -115,11 +115,11 @@ If you don't see all 3 channels, you may be limited to certain channels by your 
 
 9. Read the [Microsoft Insider Privacy Statement](https://privacy.microsoft.com/privacystatement) and the [Microsoft Insider Program Agreement](https://insider.windows.com/program-agreement), then click **Confirm**.
 
-<img src="./img/windows-insider/10/agreement.png" width="500px">
+![](./img/windows-insider/10/agreement.png)
 
 10. Choose to **Restart Now** or **Restart Later**, then you will start receiving insider builds in **Settings> Updates & Security> Windows Update**. Have fun testing Windows Builds!
 
-<img src="./img/windows-insider/10/restart.png" width="500px">
+![](./img/windows-insider/10/restart.png)
 
 ## Leaving the Windows Insider Program
 
@@ -129,23 +129,23 @@ If you don't want to participate in the Windows Insider Program anymore, you can
 
 1. Open *Settings*, click on *Updates & Security*
 
-<img src="./img/windows-insider/11/settings-home.png" width="500px">
+![](./img/windows-insider/11/settings-home.png)
 
 2. Click on **Windows Insider Program**
 
-<img src="./img/windows-insider/11/settings-select.png" width="500px">
+![](./img/windows-insider/11/settings-select.png)
 
 3. Click on **Stop getting preview builds**.
 
-<img src="./img/windows-insider/11/leaving-get-started.png" width="500px">
+![](./img/windows-insider/11/leaving-get-started.png)
 
 4. Click on **Leaving the Insider Program**.
 
-<img src="./img/windows-insider/11/unenroll-immediately.png" width="500px">
+![](./img/windows-insider/11/unenroll-immediately.png)
 
 5. You will be redicted to an official website. Click on *Leave the Program now*.
 
-<img src="./img/windows-insider/10/leaving-the-program.png" width="500px">
+![](./img/windows-insider/10/leaving-the-program.png)
 
 ::: tip
 If you see **You must login to leave the program**, login on the top right corner of the website.
@@ -153,7 +153,7 @@ If you see **You must login to leave the program**, login on the top right corne
 
 6. Click on **Stop receiving Insider Preview Builds**.
 
-<img src="./img/windows-insider/10/stop-receiving-builds.png" width="500px">
+![](./img/windows-insider/10/stop-receiving-builds.png)
 
 7. You should see *"This email address is not registered as a Windows Insider"*.
 
@@ -163,19 +163,19 @@ You should now be unenrolled to the Windows Insider Program.
 
 1. Open *Settings*, click on *Updates & Security*
 
-<img src="./img/windows-insider/10/settings-home.png" width="500px">
+![](./img/windows-insider/10/settings-home.png)
 
 2. Click on **Windows Insider program**
 
-<img src="./img/windows-insider/10/settings-select-side.png" width="500px">
+![](./img/windows-insider/10/settings-select-side.png)
 
 3. Click on **Leave the Insider Program**.
 
-<img src="./img/windows-insider/10/leaving-get-started.png" width="500px">
+![](./img/windows-insider/10/leaving-get-started.png)
 
 4. You will be redicted to an official website. Click on *Leave the Program now*.
 
-<img src="./img/windows-insider/10/leaving-the-program.png" width="500px">
+![](./img/windows-insider/10/leaving-the-program.png)
 
 ::: tip
 If you see **You must login to leave the program**, login on the top right corner of the website.
@@ -183,7 +183,7 @@ If you see **You must login to leave the program**, login on the top right corne
 
 5. Click on **Stop receiving Insider Preview Builds**.
 
-<img src="./img/windows-insider/10/stop-receiving-builds.png" width="500px">
+![](./img/windows-insider/10/stop-receiving-builds.png)
 
 6. You should see *"This email address is not registered as a Windows Insider"*. If you don't see it, please re-complete step 3 and step 4.
 
@@ -195,13 +195,13 @@ You should now be unenrolled to the Windows Insider Program.
 
 If you see *"To manage the Windows Insider programme settings for your device and allow it to stay in the Windows Insider programme, you'll need to turn on optional diagnostic data."*, click on *"Go to Diagnostics & Feedback settings to turn on optional diagnostic data."*.
 
-<img src="./img/windows-insider/optional-diagnos.png" width="500px">
+![](./img/windows-insider/optional-diagnos.png)
 
 > Image source: [Minitool](https://www.minitool.com/news/how-to-join-windows-insider-program.html)
 
 Select **Optional diagnostic data** and return back the the Windows Insider Program page and continue with the procedure to join the program.
 
-<img src="./img/windows-insider/optional-diagnos-select.png" width="500px">
+![](./img/windows-insider/optional-diagnos-select.png)
 
 ### Windows Insider Program Page not appearing
 
@@ -213,7 +213,7 @@ Editing the registry incorrectly can cause major problems. Make sure you follow 
 
 1. click <kbd>Win</kbd> + <kbd>R</kbd> and type in `regedit`, then click <kbd>Enter</kbd>
 
-<img src="./img/windows-insider/run.png" width="300px">
+<img src="./img/windows-insider/run.png" width="400px">
 
 ::: tip
 You might be prompted with the User Account Control popup, click yes or enter an adminstrator's username and password to continue.
@@ -221,7 +221,7 @@ You might be prompted with the User Account Control popup, click yes or enter an
 
 2. Go to the following registry key: `HKEY_LOCAL_MACHINE/SOFTWARE/Microsoft/WindowsSelfHost/UI/Visibility`
 
-<img src="./img/windows-insider/registry-1.png" width="500px">
+![](./img/windows-insider/registry-1.png)
 
 ::: tip
 If the registry key does not exist, right click the key `UI` on the side bar and click **New > Key** and name it `Visibility`.
@@ -229,7 +229,7 @@ If the registry key does not exist, right click the key `UI` on the side bar and
 
 3. Right click and create a new 32-bit DWORD value named `HideInsiderPage` on the right hand side. Set the value to `0`.
 
-<img src="./img/windows-insider/registry-2.png" width="500px">
+![](./img/windows-insider/registry-2.png)
 
 You may now close the Registry Editor window and restart your computer. The Windows Insider Program page should appear after the restart.
 


### PR DESCRIPTION
In most articles we add images in plain HTML syntax just to specify width. In VuePress, there wasn't any limited width for article containers. VitePress has a max width of 688px (as of the time of the commit) for article containers. Thus it's unnecessary to limit image width, and may make some images unreadable without zooming on desktops.